### PR TITLE
ci: GitHub AppのトークンではなくGitHub Actionsのデフォルトのトークンを使用する

### DIFF
--- a/.github/workflows/danger-outside.yml
+++ b/.github/workflows/danger-outside.yml
@@ -10,12 +10,12 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'ok to danger')
 
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.APP_ID_DANGERBOT }}
-          private_key: ${{ secrets.APP_PEM_DANGERBOT }}
+      # - name: Generate token
+      #   id: generate_token
+      #   uses: tibdex/github-app-token@v1
+      #   with:
+      #     app_id: ${{ secrets.APP_ID_DANGERBOT }}
+      #     private_key: ${{ secrets.APP_PEM_DANGERBOT }}
 
       - uses: actions/checkout@v3
 
@@ -30,4 +30,4 @@ jobs:
       - name: "Danger"
         run: npx danger ci --removePreviousComments
         env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -10,12 +10,12 @@ jobs:
     if: github.repository == 'nomifactory-ja/nomifactory-ja'
 
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.APP_ID_DANGERBOT }}
-          private_key: ${{ secrets.APP_PEM_DANGERBOT }}
+      # - name: Generate token
+      #   id: generate_token
+      #   uses: tibdex/github-app-token@v1
+      #   with:
+      #     app_id: ${{ secrets.APP_ID_DANGERBOT }}
+      #     private_key: ${{ secrets.APP_PEM_DANGERBOT }}
 
       - uses: actions/checkout@v3
 
@@ -30,4 +30,4 @@ jobs:
       - name: "Danger"
         run: npx danger ci --removePreviousComments
         env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
danger-jsはGitHub Actionsで使用する場合はGitHub Appのトークンを使用しないことが推奨されているように見える

Workflowのファイルがあった場合に固定値を返すなどしており、プラクティスとしてもGitHub Appを使うようにはなっていないので素直に従うことにする

see also https://github.com/danger/danger-js/blob/ad3c5426620eb4f72eae0b19fff203c006d82626/source/platforms/github/GitHubAPI.ts#L138